### PR TITLE
Joint nowcasting

### DIFF
--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -326,10 +326,11 @@ This is because we are fitting a model to the reporting triangle which is a much
 
 ::: {.callout-note collapse="true"}
 ## Key learning points
-- The renewal equation provides a better reflection of epidemic dynamics than simple geometric random walks
+- The renewal equation provides a better reflection of epidemic dynamics than simple geometric random walks as it is closer to the true generative process of the data.
 - When reporting delays don't provide enough information to identify recent trends, the underlying generative model (renewal process) prevents bias
 - Joint models can simultaneously estimate delays, nowcast, AND reproduction numbers without spurious declining trends
-- Such models are computationally intensive but provide the most accurate and comprehensive real-time epidemic assessment
+- Such models are computationally intensive but provide the most accurate and comprehensive real-time epidemic assessment. 
+They avoid issues of passing estimates between the nowcast and the reproduction number estimation model.
 :::
 
 ::: {.callout-note}

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -6,9 +6,14 @@ bibliography: ../nfidd.bib
 
 # Introduction
 
-In the last session we introduced the idea of nowcasting using a simple model. However, this approach had problems: we didn't fully account for uncertainty, or for example observation error in the primary events, and it's not a fully generative model of the data reporting process. And as we saw, if we get the delay distribution wrong, we can get the nowcast very wrong. 
+In the last session we introduced the idea of nowcasting using a simple model. 
+However, this approach had problems: we didn't fully account for uncertainty, or for example observation error in the primary events, and it's not a fully generative model of the data reporting process. 
+And as we saw, if we get the delay distribution wrong, we can get the nowcast very wrong. 
 
-A better approach is to jointly estimate the delay distribution together with the nowcast. We can do this by using information from multiple snapshots of the data as it changes over time (using a data structure called the "reporting triangle"). In this session, we'll introduce this approach to joint estimation in nowcasting. At the end we'll then demonstrate a way to combine this with our previous work estimating the reproduction number, steadily improving our real time outbreak model.
+A better approach is to jointly estimate the delay distribution together with the nowcast. 
+We can do this by using information from multiple snapshots of the data as it changes over time (using a data structure called the "reporting triangle"). 
+In this session, we'll introduce this approach to joint estimation in nowcasting. 
+At the end we'll then demonstrate a way to combine this with our previous work estimating the reproduction number, steadily improving our real time outbreak model.
 
 ## Slides
 
@@ -60,43 +65,20 @@ options(cmdstanr_print_line_numbers = TRUE)
 
 ## Motivation
 
-So far we have assumed that the delay distribution is known. In practice, this is often not the case and we need to estimate it from the data.
-As we discussed in the [session on biases in delay distributions](sessions/biases-in-delay-distributions), this can be done using individual data and then passing this estimate to a simple nowcasting model like those above.
-However, this has the disadvantage that the nowcasting model does not take into account the uncertainty in the delay distribution or observation error of the primary events.
-We can instead estimate the delay distribution and nowcast the data jointly.
+In the [nowcasting concepts session](sessions/nowcasting) we saw that getting the delay distribution wrong can lead to very poor nowcasts. 
+We also saw that simple nowcasting models don't fully account for uncertainty or observation error in the primary events.
 
-## The reporting triangle
+A better approach is to jointly estimate the delay distribution together with the nowcast. 
+This builds on the data simulation approach we used in the concepts session, but now we model the entire process at the population level with observation error.
 
-To jointly estimate we need to decompose observations into what is known as the reporting triangle.
-This is a matrix where the rows are the days of onset and the columns are the days of report.
-The entries are the number of onsets on day $i$ that are reported on day $j$.
-We can then use this matrix to estimate the delay distribution and nowcast the data.
-It is referred to as a triangle because the data for the more recent data entries are incomplete which gives the matrix a triangular shape.
+## Extending our data simulation approach
 
-We can construct the reporting triangle from onsets ($N_{t}$) as follows:
-$$
-N_{t} = \sum_{d=0}^{D} n_{t,d}
-$$
+Recall from the [nowcasting concepts session](sessions/nowcasting) that we simulated individual reporting delays and then aggregated them. 
+Now we'll simulate the same process but at the population level with observation error - for the same reasons we made this change in the [convolutions session](sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic).
 
-Where $n_{t,d}$ is the number of onsets on day $t$ that are reported on day $t+d$ and $D$ represents the maximum delay between date of reference and time of report which in theory could be infinite but in practice we set to a finite value to make the model identifiable and computationally feasible.
-We can now construct a model to estimate $n_{t,d}$,
+Instead of simulating individual delays, we'll simulate the entire reporting process at the population level. 
 
-$$
-  n_{t,d} \mid \lambda_{t},p_{t,d} \sim \text{Poisson} \left(\lambda_{t} \times p_{t,d} \right),\ t=1,...,T.
-$$
-
-where $\lambda_{t}$ is the expected number of onsets on day $t$ and $p_{t,d}$ is the probability that an onset on day $t$ is reported on day $t+d$.
-Here $\lambda_{t}$ is the same as the expected number of onsets on day $t$ in the simple nowcasting model above so we again modelled it using a geometric random walk for now.
-We model $p_{t,d}$ as a [Dirichlet distribution](https://distribution-explorer.github.io/multivariate_continuous/dirichlet.html) as it is a distribution over probabilities.
-$p_{t,d}$ is equivalent to the reporting delays we have been using as fixed quantities so far but now estimated within the model.
-In most real-world settings we would want to use our domain expertise to inform the prior distribution of $p_{t,d}$.
-
-## Simulating the reporting triangle
-
-Now that we are aiming to jointly estimate the delay distribution we need additional data.
-We can simulate this data by using the same generative process as above but now also simulating the reporting delays.
-
-Once again we generate our simulated onset dataset:
+First, let's generate our simulated onset dataset as before:
 
 ```{r, load-simulated-onset}
 gen_time_pmf <- make_gen_time_pmf()
@@ -108,7 +90,7 @@ head(onset_df)
 cutoff <- 71
 ```
 
-We also need to simulate the reporting delays:
+We then need to simulate the reporting delays:
 
 ```{r simulate-reporting-delays}
 reporting_delay_pmf <- censored_delay_pmf(
@@ -117,7 +99,7 @@ reporting_delay_pmf <- censored_delay_pmf(
 plot(reporting_delay_pmf)
 ```
 
-We can then simulate the reporting triangle:
+We can then simulate the data by day, onset day, and reporting day by applying the reporting delay distribution to the onsets (notice how this is nearly identical to the convolution we saw in the [convolutions session](sessions/using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic) expect that we are not applying the sum):
 
 ```{r simulate-reporting-triangle}
 reporting_triangle <- onset_df |>
@@ -134,26 +116,103 @@ reporting_triangle <- onset_df |>
   mutate(reported_day = day + d)
 ```
 
-We also need to update our simulated truth data to include the Poisson observation error we are assuming is part of the observation process.
+We also apply the Poisson observation error to the reported onsets to capture our uncertainty in the reporting process (remember we have lost uncertainty in the onsets as we are not individually simulating the reporting delays).
 
 ```{r update-simulated-onset}
 noisy_onsets_df <- reporting_triangle |>
   summarise(noisy_onsets = sum(reported_onsets), .by = day)
 ```
 
-As we only partially observe the reporting triangle we need to filter it to only include the data we have observed:
+As we only observed reported cases up to the current day we need to filter it to only include the data we have observed:
 
 ```{r filter-reporting-triangle}
 filtered_reporting_triangle <- reporting_triangle |>
   filter(reported_day <= max(day))
 ```
 
-Finally, we sum the filtered reporting triangle to get the counts we actually observe.
+Finally, we sum this to get the counts we actually observe. This is the same as the date we corrected for **right truncation** in the [nowcasting concepts session](sessions/nowcasting).
 
 ```{r counts-observed}
 available_onsets <- filtered_reporting_triangle |>
   summarise(available_onsets = sum(reported_onsets), .by = day)
 ```
+
+## Understanding the data structure
+
+Notice how this simulation creates a different data structure than in the concepts session.
+
+::: {.callout-important}
+## Three dimensional epidemiological data
+
+So far we've worked with data that has two dimensions. Such as:
+- **Onset day**: when symptoms began
+- **Onset counts**: the number of cases that occurred on each day
+
+Now we are introdcing a third dimension:
+- **Report day**: when the case enters our surveillance system
+
+This means that to recover the true onset counts we need to sum across the third dimension and we may not be able to do this if all the data has not been reported yet (i.e. we have right truncation in our data).
+This is just a **reformulation** of the nowcasting problem we saw in the [nowcasting concepts session](sessions/nowcasting).
+
+:::
+
+This richer data structure contains information about both the delay distribution and the final expected counts so we can use it to jointly estimate both which was not possible with the simpler data structure we used in the [nowcasting concepts session](sessions/nowcasting).
+
+## Mathematical formulation
+
+We can formalise this process mathematically.
+The total number of onsets on day $t$ is:
+$$
+N_{t} = \sum_{d=0}^{D} n_{t,d}
+$$
+
+where $n_{t,d}$ is the number of onsets on day $t$ that are reported on day $t+d$, and $D$ is the maximum delay.
+
+We model each component as:
+$$
+  n_{t,d} \mid \lambda_{t},p_{t,d} \sim \text{Poisson} \left(\lambda_{t} \times p_{t,d} \right),\ t=1,...,T.
+$$
+
+where:
+- $\lambda_{t}$ is the expected number of onsets on day $t$
+- $p_{t,d}$ is the probability that an onset on day $t$ is reported on day $t+d$
+
+This approach jointly estimates the delay distribution ($p_{t,d}$) and the underlying onset counts ($\lambda_{t}$) from the observed data.
+
+::: {.callout-important}
+## Modelling options
+
+We now have two main modelling options:
+  - How we model the expected number of onsets $\lambda_{t}$
+  - How we model the probability of reporting $p_{t,d}$
+
+We will explore these in the next section.
+:::
+
+A key insight is that we can split each $n_{t,d}$ into observed and unobserved components:
+
+$$n_{t,d} = n_{t,d}^{obs} + n_{t,d}^{miss}$$
+
+where:
+- $n_{t,d}^{obs}$ is what we observe (when $t+d \leq$ current day)
+- $n_{t,d}^{miss}$ is what we need to estimate (when $t+d >$ current day)
+
+The joint model uses the observed data to estimate both the delay distribution and the underlying onset counts, which then allows us to predict the missing entries.
+
+::: {.callout-note collapse="true"}
+## The reporting triangle
+
+This data structure is sometimes called the "reporting triangle" in the literature because when visualised as a matrix (with onset days as rows and reporting days as columns), the observed data ($n_{t,d}^{obs}$) creates a triangular shape.
+
+![Reporting triangle visualisation](slides/figures/reporting_triangle.png)
+
+The aim of nowcasting is to complete this triangle by estimating the missing entries ($n_{t,d}^{miss}$).
+
+![Completed reporting triangle](slides/figures/complete_reporting_triangle.png)
+
+Once completed, we sum across the rows to get our nowcast of the true onset counts.
+:::
+
 
 ## Fitting the joint model
 

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -114,6 +114,8 @@ reporting_triangle <- onset_df |>
     reported_onsets = rpois(n(), onsets * reporting_delay)
   ) |>
   mutate(reported_day = day + d)
+
+tail(reporting_triangle)
 ```
 
 We also apply the Poisson observation error to the reported onsets to capture our uncertainty in the reporting process (remember we have lost uncertainty in the onsets as we are not individually simulating the reporting delays).
@@ -121,6 +123,8 @@ We also apply the Poisson observation error to the reported onsets to capture ou
 ```{r update-simulated-onset}
 noisy_onsets_df <- reporting_triangle |>
   summarise(noisy_onsets = sum(reported_onsets), .by = day)
+
+tail(noisy_onsets_df)
 ```
 
 As we only observed reported cases up to the current day we need to filter it to only include the data we have observed:
@@ -128,6 +132,8 @@ As we only observed reported cases up to the current day we need to filter it to
 ```{r filter-reporting-triangle}
 filtered_reporting_triangle <- reporting_triangle |>
   filter(reported_day <= max(day))
+
+tail(noisy_onsets_df)
 ```
 
 Finally, we sum this to get the counts we actually observe. This is the same as the date we corrected for **right truncation** in the [nowcasting concepts session](sessions/nowcasting).
@@ -135,6 +141,8 @@ Finally, we sum this to get the counts we actually observe. This is the same as 
 ```{r counts-observed}
 available_onsets <- filtered_reporting_triangle |>
   summarise(available_onsets = sum(reported_onsets), .by = day)
+
+tail(available_onsets)
 ```
 
 ## Understanding the data structure
@@ -216,6 +224,8 @@ Once completed, we sum across the rows to get our nowcast of the true onset coun
 
 ## Fitting the joint model
 
+For fitting the joint model specification follows our data simulation approach but we have to make choices about how to model the expected number of onsets $\lambda_{t}$ and the probability of reporting $p_{t,d}$.
+
 As usual we start by loading the model:
 
 ```{r stan-joint-nowcast}
@@ -231,6 +241,17 @@ For now, it is important that you understand the concept but as the models get m
 Once thing to note is that we are now fitting the initial number of symptom onsets (`init_onsets`).
 This is different from earlier when we had to pass the initial number of infections (`I0`) as data.
 In most situations this number would be unknown so what we do here is closer to what one would do in the real world.
+:::
+
+::: {.callout-note}
+## Take two minutes
+What are the models we have picked for the onesets ($\lambda_{t}$) and the reporting delay distribution ($p_{t,d}$)?
+:::
+
+::: {.callout-note collapse="true"}
+## Solution
+- $\lambda_{t}$ is modelled using a geometric random walk.
+- $p_{t,d}$ is modelled using a Dirichlet distribution (i.e. a multinomial distribution with a constraint that the sum of the probabilities is 1 - this allows the delay distribution to be flexible).
 :::
 
 We then fit it do data:
@@ -256,7 +277,7 @@ joint_nowcast_fit
 
 ::: {.callout-important}
 One benefit of this model is that because we have decomposed the data into the reporting triangle we can make a nowcast that uses the data we have available augmented with predictions from the model.
-This should give us far more accurate uncertainty estimates than the simple nowcasting models above (see `stan/functions/combine_obs_with_predicted_obs_rng.stan` but note the code is fairly involved).
+This should give us more accurate uncertainty estimates than the simple nowcasting models above (see `stan/functions/combine_obs_with_predicted_obs_rng.stan` but note the code is fairly involved).
 :::
 
 We now extract this nowcast:

--- a/sessions/joint-nowcasting.qmd
+++ b/sessions/joint-nowcasting.qmd
@@ -242,7 +242,15 @@ This is because we are fitting a model to the reporting triangle which is a much
 :::
 
 
-# Putting it all together: Estimating the reproduction number, nowcasting, and joint estimation of delay distributions
+# Putting it all together: Estimating the reproduction number, nowcasting, and joint estimation of delay distributions {.optional}
+
+::: {.callout-note collapse="true"}
+## Key learning points
+- The renewal equation provides a better reflection of epidemic dynamics than simple geometric random walks
+- When reporting delays don't provide enough information to identify recent trends, the underlying generative model (renewal process) prevents bias
+- Joint models can simultaneously estimate delays, nowcast, AND reproduction numbers without spurious declining trends
+- Such models are computationally intensive but provide the most accurate and comprehensive real-time epidemic assessment
+:::
 
 ::: {.callout-note}
 This section contains a lot of code and is quite complex. It is not necessary to understand all of it to get the main points of the session. We recommend reading through it to get a sense of how all the pieces fit together but don't worry if you don't understand all of it.

--- a/sessions/nowcasting.qmd
+++ b/sessions/nowcasting.qmd
@@ -6,9 +6,11 @@ bibliography: ../nfidd.bib
 
 # Introduction
 
-So far we've explored the delays and biases of real-time infectious disease surveillance data, started to correct for these, and considered the underlying process that drives the evolution of epidemics (looking at the reproduction number and renewal equation). Next, we'll focus on predicting new information about how infectious disease transmission is evolving in the present and future. 
+So far we've explored the delays and biases of real-time infectious disease surveillance data, started to correct for these, and considered the underlying process that drives the evolution of epidemics (looking at the reproduction number and renewal equation). 
+Next, we'll focus on predicting new information about how infectious disease transmission is evolving in the present and future. 
 
-We know that we have incomplete information in the present because of delays in the observation process (reporting delays). The aim of nowcasting is to predict what an epidemiological time series will look like *after all delayed reports* are in, for which we need to account for the delays and biases we've already considered.
+We know that we have incomplete information in the present because of delays in the observation process (reporting delays). 
+The aim of nowcasting is to predict what an epidemiological time series will look like *after all delayed reports* are in, for which we need to account for the delays and biases we've already considered.
 
 ## Slides
 
@@ -127,7 +129,7 @@ We can see that if we plot the final data set of symptom onsets alongside the cu
 # Use full outbreak dataset
 final <- df |>
   transmute(onset_day = floor(onset_time))
-final_onset_ts <- final |>
+refinal_onset_ts <- final |>
   count(day = onset_day, name = "onsets")
 final_all_days <- expand_grid(day = seq(0, max(final_onset_ts$day))) |>
   full_join(final_onset_ts, by = "day") |>

--- a/sessions/slides/introduction-to-joint-estimation-of-nowcasting-and-reporting-delays.qmd
+++ b/sessions/slides/introduction-to-joint-estimation-of-nowcasting-and-reporting-delays.qmd
@@ -39,28 +39,17 @@ One potential solution is to jointly estimate the reporting delays and the nowca
 
 ![](figures/germany_historical.png)
 
-### The reporting triangle
+### Building on previous methods
 
-The reporting triangle is the name given to the data structure that arises when we have multiple snapshots of the data.
+The joint model has three key components:
 
-![](figures/reporting_triangle.png)
-
-### The reporting triangle
-
-Here the rows represent the time of the primary event, and the columns represent the time of the report.
-Some events are missing because they are yet to happen.
-
-![](figures/reporting_triangle.png)
-
-### Completing the reporting triangle
-
-The aim of nowcasting is to complete the reporting triangle. This means filling in the missing entries in the lower triangle and then summing the rows to get the nowcast.
-
-![](figures/complete_reporting_triangle.png)
+1. **Model for underlying counts** (what will end up being reported)
+2. **Model for delay distribution** (how long the reporting process will be)
+3. **Apply delays to counts** (transform onset dates to report dates (like a convolution but we don't take the sum)))
 
 ## `r fontawesome::fa("laptop-code", "white")` Your Turn {background-color="#447099" transition="fade-in"}
 
-1. Simulate the reporting triangle
+1. Simulate data with delayed reporting
 2. Perform a joint estimation of the delay and nowcast
 3. Understand the limitations of the data generating process
 4. Perform a joint estimation of the delay, nowcast, and reproduction number


### PR DESCRIPTION
  Comprehensively improve the joint nowcasting session to fit the reduced 1-hour timeframe and address pedagogical concerns about the confusing reporting triangle discussion.

  ## Key Changes

  ### 🎯 Timing Optimizations
  - Mark joint R estimation section as optional with collapsible summary of key learning points
  - Move reporting triangle discussion to optional callout with figures
  - Focus core session on joint nowcasting concepts

  ### 📚 Pedagogical Improvements
  - **Simulation-first approach**: Start with familiar data simulation, then introduce mathematical formulation
  - **Better connections**: Explicitly link to concepts session and explain population-level modeling rationale
  - **Interactive elements**: Add "take 2 minutes" exercises to engage learners with model choices
  - **Data structure visibility**: Add `tail()` calls to show data transformations

  ### 🔧 Content Restructuring
  - Replace confusing reporting triangle slides with clearer explanation of joint model components
  - Introduce three-dimensional data concept with clear explanation
  - Add observed vs unobserved notation (n^obs vs n^miss) to clarify what we're estimating
  - Reference convolutions session for population-level modeling rationale

  ## New Session Flow
  1. **5 mins**: Motivation + simplified slides
  2. **15 mins**: Data simulation building on concepts
  session
  3. **10 mins**: Mathematical formulation (motivated by
  simulation)
  4. **15 mins**: Fitting joint model with interactive
  exercises
  5. **10 mins**: Results + discussion
  6. **Optional**: Joint R estimation with key learning points summary

  This restructuring eliminates the confusing reporting triangle exposition while maintaining all core learning objectives in a more pedagogically sound and time-appropriate format.
