### PR TITLE
Add Quarto freeze caching for sessions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,6 +33,16 @@ jobs:
         with:
           use-public-rspm: true
 
+      # Cache Quarto freeze directory for computational results
+      # This prevents re-running expensive computations (Stan models, simulations)
+      - name: Cache Quarto freeze
+        uses: actions/cache@v4
+        with:
+          path: _freeze
+          key: quarto-freeze-${{ runner.os }}-${{ hashFiles('sessions/**/*.qmd', 'sessions/**/*.Rmd') }}
+          restore-keys: |
+            quarto-freeze-${{ runner.os }}-
+
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ inst/stan/*
 *pdf
 CLAUDE.md
 sismid-ili-forecasting-sandbox/
+
+# Quarto freeze directory
+_freeze/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -31,6 +31,9 @@ website:
       style: "docked"
       contents: "sessions/*.qmd"
 
+execute:
+  freeze: auto
+
 format:
   html:
     theme:

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -14,7 +14,6 @@ For example, the incubation period might be used to determine the appropriate le
 We also need to have some estimate for these delays when interpreting new data, in order to understand what is happening now ^[Much like Alice through the Looking Glass, it often seems like we are [running to stay in the same place](https://en.wikipedia.org/wiki/Red_Queen%27s_race)!] and predict what might happen in the future.
 However, the length of time between any of these events might be highly variable (between individuals) and fundamentally uncertain (across the population as a whole). We capture this variability using probability distributions, which is the focus of this session.
 
-TEST CHANGE - do not merge
 ## Slides
 
 - [Introduction to epidemiological delays](slides/introduction-to-epidemiological-delays)

--- a/sessions/delay-distributions.qmd
+++ b/sessions/delay-distributions.qmd
@@ -14,6 +14,7 @@ For example, the incubation period might be used to determine the appropriate le
 We also need to have some estimate for these delays when interpreting new data, in order to understand what is happening now ^[Much like Alice through the Looking Glass, it often seems like we are [running to stay in the same place](https://en.wikipedia.org/wiki/Red_Queen%27s_race)!] and predict what might happen in the future.
 However, the length of time between any of these events might be highly variable (between individuals) and fundamentally uncertain (across the population as a whole). We capture this variability using probability distributions, which is the focus of this session.
 
+TEST CHANGE - do not merge
 ## Slides
 
 - [Introduction to epidemiological delays](slides/introduction-to-epidemiological-delays)


### PR DESCRIPTION
## Summary
  - Implements Quarto freeze caching to speed up session rendering
  - Adds GitHub Actions cache for `_freeze` directory

  ## Changes
  - Configure `_quarto.yml` with `freeze: auto`
  - Add GitHub Actions cache step for `_freeze` directory
  - Update `.gitignore` to exclude freeze directory

  ## Benefits
  - Faster local development and CI builds
  - Reliable caching without cache corruption issues
  - Automatic invalidation when content changes

  ## Test Plan
  - [x] Test cache miss: Make minor change to a session file and
  verify it re-renders that session only
  - [x] Test cache hit: Make README-only change and verify
  sessions are not re-rendered
  - [x] Verify GitHub Actions cache is created and restored
  properly
  - [x] Check that `_freeze` directory is excluded from repository
   but cached in Actions

  🤖 Generated with [Claude Code](https://claude.ai/code)