### PR TITLE
Review forecasting nowcasting

### DIFF
--- a/sessions/forecasting-nowcasting.qmd
+++ b/sessions/forecasting-nowcasting.qmd
@@ -163,6 +163,44 @@ complete_threshold <- 14
 complete_data <- available_onsets |>
   filter(day <= cutoff - complete_threshold)
 
+::: {.callout-tip collapse="true"}
+## Choosing the "complete data" threshold
+
+We've chosen 14 days as our threshold for "complete" data, but this is quite conservative. 
+Let's examine what proportion of reports we expect to have received by different delays:
+
+```{r show-reporting-cdf}
+# Calculate cumulative reporting proportions
+reporting_cdf <- cumsum(reporting_delay_pmf)
+tibble(
+  delay = 0:15,
+  pmf = reporting_delay_pmf,
+  cdf = reporting_cdf
+) |>
+  filter(delay %in% c(1, 3, 5, 7, 10, 14)) |>
+  mutate(
+    `Proportion reported` = round(cdf, 3),
+    `Proportion missing` = round(1 - cdf, 3)
+  ) |>
+  select(
+    `Days since onset` = delay,
+    `Proportion reported`,
+    `Proportion missing`
+  ) |>
+  knitr::kable(caption = "Expected reporting completeness by delay")
+```
+
+As we can see, after 5 days we expect to have received ~`r round(reporting_cdf[6]*100)`% of reports, and after 7 days ~`r round(reporting_cdf[8]*100)`%.
+Using a 14-day threshold means we're losing 7-9 days of potentially useful data.
+
+**Trade-offs to consider:**
+- **Less conservative thresholds** (e.g., 5-7 days): Use more recent data but need to account for 5-15% missing reports
+- **More conservative thresholds** (e.g., 14 days): Very complete data but lose recent epidemic trends
+- **Nowcasting approaches**: Use all available data and explicitly model the reporting process
+
+Try experimenting with different thresholds (e.g., `complete_threshold <- 7`) to see how it affects the forecasts!
+:::
+
 # Visualise the different datasets
 ggplot() +
   geom_line(data = complete_at_horizon, 

--- a/sessions/forecasting-nowcasting.qmd
+++ b/sessions/forecasting-nowcasting.qmd
@@ -87,6 +87,31 @@ Some methods (particularly Bayesian generative models) make this connection expl
 We'll start by generating synthetic data that mimics the challenges we face in real-time epidemic analysis.
 This builds on the approach from the [joint nowcasting session](sessions/joint-nowcasting), but now we'll also create a dataset filtered at a two-week forecast horizon for evaluation (i.e. the data that we would ultimately observe for the two weeks after the forecast date).
 
+::: {.callout-note}
+## Connecting to ILI forecasting
+
+While we use linelist-based data (individual symptom onsets with reporting delays) for clarity in this session, the forecasting sessions focus on ILI percentage data.
+These data types differ substantially:
+
+**Our simulated data:**
+- Individual events with systematic reporting delays
+- Delays cause under-reporting that resolves over time
+- Clear temporal progression: infection → onset → report
+
+**ILI surveillance data (from forecasting sessions):**
+- Compound measure: % of visits for influenza-like illness
+- Can be revised up OR down as reports arrive
+- Combines multiple diseases and reporting locations
+
+**Adapting these methods for ILI:**
+- The joint modelling framework can handle bidirectional revisions by modelling the full revision process with minor modifications
+- Pipeline approaches may need separate models for upward and downward revisions
+- Understanding the data generation process (how individual reports → ILI %) helps identify biases
+- Performance may be limited by the complexity of the compound measure
+
+The key insight is that whether dealing with simple delays or complex revisions, combining nowcasting and forecasting in a coherent framework improves predictions.
+:::
+
 ## Generate the underlying epidemic
 
 First, let's generate our simulated onset dataset as we did in previous sessions:

--- a/sessions/forecasting-nowcasting.qmd
+++ b/sessions/forecasting-nowcasting.qmd
@@ -196,6 +196,23 @@ ggplot() +
   theme(legend.position = "bottom")
 ```
 
+::: {.callout-note}
+## Pipeline approaches vs joint models
+
+In this session, we'll explore different ways to combine nowcasting and forecasting.
+Building on methods from our earlier sessions, you could construct pipeline approaches using:
+
+- **Delay distribution estimation**: Methods from the [biases in delay distributions session](sessions/biases-in-delay-distributions) to estimate reporting delays from individual-level data
+- **Simple nowcasting**: The geometric random walk nowcasting model from the [nowcasting concepts session](sessions/nowcasting) 
+- **Multiplicative baseline methods**: Simple CDF-based scaling approaches using tools like [`baselinenowcast`](https://baselinenowcast.epinowcast.org)
+- **Reproduction number estimation**: Methods from the [R estimation session](sessions/R-estimation-and-the-renewal-equation) applied to the nowcasted data
+
+Each component can be developed and validated independently, making pipeline approaches more modular and sometimes easier to debug.
+The trade-off is that uncertainty may not propagate correctly between components, and the assumptions of each component may not be consistent with each other.
+
+As we'll see, joint models that estimate nowcasts and forecasts together can address these limitations, but come with their own challenges in terms of complexity and computational requirements.
+:::
+
 # Approach 1: Complete data approach
 
 The simplest approach is to filter to only "complete" data and forecast from there using the renewal model from the [reproduction number session](R-estimation-and-the-renewal-equation).

--- a/sessions/nowcasting.qmd
+++ b/sessions/nowcasting.qmd
@@ -282,6 +282,23 @@ The points in this plot represent the data available when the nowcast was made (
 As we found in the [using delay distributions to model the data generating process of an epidemic session](using-delay-distributions-to-model-the-data-generating-process-of-an-epidemic#estimating-a-time-series-of-infections), this simple model struggles to recreate the true number of onsets. This is because it does not capture the generative process of the data (i.e. the transmission process and delays from infection to onset). In the next section we will see how we can use a model that does capture this generative process to improve our nowcasts.
 :::
 
+::: {.callout-important}
+## Simple multiplicative nowcasting methods
+
+Before moving to more complex models, it's worth noting that there is an even simpler nowcasting method that simply divides currently observed counts by the cumulative distribution function (CDF) of the delay distribution. 
+This approach is often called "multiplicative" or "scaling" nowcasting.
+
+While this method appears simple, it still embodies a model with specific assumptions that can be difficult to define precisely. 
+Key challenges include:
+- The method struggles with noisy data, particularly when counts are low
+- Sparse data (e.g., zero counts) can lead to unstable estimates
+- Generating uncertainty
+- The implicit assumptions about the data generating process are not always clear
+
+The [`baselinenowcast`](https://baselinenowcast.epinowcast.org) R package provides a set of tools for these types of methods, including approaches to handle both noise and sparsity in the data. 
+These baseline methods can serve as useful benchmarks when developing more complex nowcasting models.
+:::
+
 ## Adding in a geometric random walk to the nowcasting model
 
 As we saw in the [session on the renewal equation](R-estimation-and-the-renewal-equation), a geometric random walk is a simple way to model multiplicative growth. Adding this into our simple nowcasting model may help us to better capture the generative process of the data and so produce a better nowcast.
@@ -407,6 +424,7 @@ What do you think of the nowcast now? How would you know you had the wrong delay
 ## Methods in practice
 
 - Wolffram et al., [Collaborative nowcasting of COVID-19 hospitalization incidences in Germany](https://doi.org/10.1371/journal.pcbi.1011394) compares the performance of a range of methods that were used in a nowcasting hub and investigates what might explain performance differences.
+- The [`{baselinenowcast}`](https://baselinenowcast.epinowcast.org) R package provides implementations of simple multiplicative nowcasting methods that can serve as baselines for comparison with more complex approaches.
 
 # Wrap up
 


### PR DESCRIPTION
## Summary

  This PR adds important clarifications and connections between
  nowcasting/forecasting methods and real-world data complexities,
   addressing feedback from #70.

  ## Changes

  ### Nowcasting session (`sessions/nowcasting.qmd`)
  - Added callout about simple multiplicative/CDF-based nowcasting
   methods after the simple model introduction
  - Added `baselinenowcast` R package to the "Methods in practice"
   section
  - Explains that while these methods appear simple, they embody
  specific model assumptions and struggle with noisy/sparse data

  ### Forecasting-nowcasting session
  (`sessions/forecasting-nowcasting.qmd`)
  - Added callout explaining pipeline approaches using methods
  from earlier sessions
  - Added collapsed callout about choosing "complete data"
  thresholds with a table showing reporting completeness at
  different delays
  - Added callout connecting linelist data (used in examples) to
  ILI percentage data (used in forecasting sessions)

  ## Key improvements

  1. **Multiplicative nowcasting context**: Provides important
  baseline method context and tools for comparison
  2. **Threshold flexibility**: Addresses concern that 14-day
  threshold is overly conservative by showing actual reporting
  completeness
  3. **ILI data connection**: Bridges the gap between
  linelist-focused nowcasting methods and ILI-focused forecasting
  content
  4. **Pipeline approach clarity**: Explicitly connects methods
  from different sessions into coherent pipelines

  ## Addresses feedback

  - Clarifies that presented methods primarily handle systematic
  under-reporting, not bidirectional revisions common in ILI data
  - Explains complexities of compound surveillance measures like
  ILI percentages
  - Provides guidance on adapting methods for real-world
  surveillance systems
  - Encourages experimentation with less conservative completeness
   thresholds